### PR TITLE
bump requirements for php8 & SF5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,14 +30,14 @@
     }
   },
   "require": {
-    "php": "^7.1",
+    "php": ">=7.1",
     "onesky/api-library-php5": "^1.0",
-    "symfony/dependency-injection": "~2.8|~3.0|~4.0",
-    "symfony/console": "~2.8|~3.0|~4.0",
-    "symfony/config": "~2.8|~3.0|~4.0",
-    "symfony/finder": "~2.8|~3.0|~4.0",
-    "symfony/framework-bundle": "~2.8|~3.0|~4.0",
-    "symfony/http-kernel": "~2.8|~3.0|~4.0",
+    "symfony/dependency-injection": ">=2.8",
+    "symfony/console": ">=2.8",
+    "symfony/config": ">=2.8",
+    "symfony/finder": ">=2.8",
+    "symfony/framework-bundle": ">=2.8",
+    "symfony/http-kernel": ">=2.8",
     "ext-json": "*"
   },
   "require-dev": {


### PR DESCRIPTION
open constraints so we will not have to change every time we try to upgrade